### PR TITLE
Update possible moves to be outlines and not backgrounds

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -219,7 +219,15 @@ Usually called when the game is over.</td><td></td>
        </tr>
      
        <tr>
-         <td>--hexchess-attempted-move-bg</td><td>The fill color of a hexgon when the user drags over a square, trying to move there. Custom events</td>
+         <td>--hexchess-attempted-move-white-stroke</td><td>The outline color of a hexagon when the user drags over a white square, trying to move there.</td>
+       </tr>
+     
+       <tr>
+         <td>--hexchess-attempted-move-grey-stroke</td><td>The outline color of a hexagon when the user drags over a grey square, trying to move there.</td>
+       </tr>
+     
+       <tr>
+         <td>--hexchess-attempted-move-black-stroke</td><td>The outline color of a hexagon when the user drags over a black square, trying to move there. Custom events</td>
        </tr>
      
    </table>

--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -595,7 +595,11 @@ export class HexchessBoard extends LitElement {
   private _getColorForSquare(square: Square): TileColor {
     const colors = this._columnConfig[square[0] as Column].colors;
     const number = parseInt(square.slice(1));
-    return number % 3 === 0 ? colors[0] : number % 3 === 1 ? colors[1] : colors[2];
+    return number % 3 === 0
+      ? colors[0]
+      : number % 3 === 1
+      ? colors[1]
+      : colors[2];
   }
 
   // -----------------
@@ -959,11 +963,11 @@ export class HexchessBoard extends LitElement {
         ${this._renderHexagon(
           this._polygonWidth,
           this._polygonHeight,
-          `possible-move-${this._getColorForSquare(this._state.dragSquare)}`,
+          `possible-move-${this._getColorForSquare(this._state.dragSquare)}`
         )}
       </g>
     `;
-}
+  }
 
   private _renderDot(
     width: number,
@@ -1005,7 +1009,15 @@ export class HexchessBoard extends LitElement {
       class="possible-move" />`;
   }
 
-  private _renderHexagon(width: number, height: number, className: TileColor | 'possible-move-white' | 'possible-move-black' | 'possible-move-grey') {
+  private _renderHexagon(
+    width: number,
+    height: number,
+    className:
+      | TileColor
+      | 'possible-move-white'
+      | 'possible-move-black'
+      | 'possible-move-grey'
+  ) {
     return svg`<polygon
       points=${this._calculateHexagonPointsAsString(width, height)}
       class="${className}" />`;

--- a/src/hexchess-styles.ts
+++ b/src/hexchess-styles.ts
@@ -86,7 +86,9 @@ export const styles = css`
     fill: none;
   }
 
-  .possible-move-grey, .possible-move-black, .possible-move-white {
+  .possible-move-grey,
+  .possible-move-black,
+  .possible-move-white {
     stroke-width: 5;
     fill: none;
     pointer-events: none;

--- a/src/hexchess-styles.ts
+++ b/src/hexchess-styles.ts
@@ -86,8 +86,20 @@ export const styles = css`
     fill: none;
   }
 
-  .possible-move > polygon {
-    fill: var(--hexchess-possible-move-bg, #e4c7b7);
+  .possible-move-grey, .possible-move-black, .possible-move-white {
+    stroke-width: 5;
+    fill: none;
+    pointer-events: none;
+  }
+
+  polygon.possible-move-white {
+    stroke: var(--hexchess-possible-move-stroke-white, #e4c7b7);
+  }
+  polygon.possible-move-black {
+    stroke: var(--hexchess-possible-move-stroke-black, #e4c7b7);
+  }
+  polygon.possible-move-grey {
+    stroke: var(--hexchess-possible-move-stroke-grey, #e4c7b7);
   }
 
   .score {


### PR DESCRIPTION
1. Create 3 new CSS variables to allow customization of the outline color depending on the initial color of the hexagon

2. Use outlines instead of backgrounds, so in the future we can show custom backgrounds and outlines on the same tile

3. Update the documentation based on these changes


https://github.com/hexagonchess/hexchess-board/assets/48705139/90c8b8df-e219-4d97-8a28-5c1a24198df8