### PR TITLE
Highlight the most recently played move

### DIFF
--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -904,13 +904,22 @@ export class HexchessBoard extends LitElement {
           const color = this._getColorForSquare(square);
 
           // Rendering classes
+          const isRecentFrom =
+            this._state.name !== 'REWOUND' &&
+            this._state.moves.length > 0 &&
+            this._state.moves[this._state.moves.length - 1].from === square;
+          const isRecentTo =
+            this._state.name !== 'REWOUND' &&
+            this._state.moves.length > 0 &&
+            this._state.moves[this._state.moves.length - 1].to === square;
           const isSelected =
             this._state.name !== 'WAITING' &&
             this._state.name !== 'REWOUND' &&
             this._state.name !== 'PROMOTING' &&
             this._state.name !== 'GAMEOVER' &&
             this._state.square === square;
-          const selectedClass = isSelected ? 'selected' : '';
+          const selectedClass =
+            isSelected || isRecentFrom || isRecentTo ? 'selected' : '';
 
           // Offsets
           const offset = this._getOffsets(square, this._columnConfig);


### PR DESCRIPTION
Similar to Chess.com's functionality, highlight the most recently made move.

Also make sure that even though a square is highlighted, it can still be selected as a 'possible move' with an outline.

Fixes #4 

https://github.com/hexagonchess/hexchess-board/assets/48705139/e3b620f1-8de5-4a15-8cb5-da93de5850eb