### PR TITLE
Fix the default capture color and selected color clashing

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -219,6 +219,10 @@ Usually called when the game is over.</td><td></td>
        </tr>
      
        <tr>
+         <td>--hexchess-possible-capture-bg</td><td>The stroke color of the large circle outlining a piece that can be captured.</td>
+       </tr>
+     
+       <tr>
          <td>--hexchess-attempted-move-white-stroke</td><td>The outline color of a hexagon when the user drags over a white square, trying to move there.</td>
        </tr>
      

--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -42,7 +42,8 @@ import {Game, GameState} from './game';
  * @cssprop [--hexchess-selected-grey-bg=#a96a41]            - The background color of a grey tile that's selected to be moved.
  * @cssprop [--hexchess-label-bg=#ffffff]                    - The background color of the column and row labels.
  * @cssprop [--hexchess-label-size=12px]                     - The font size of the column and row labels.
- * @cssprop [--hexchess-possible-move-bg=#a96a41]            - The fill color of the small dot shown on a hexagon indicating this is a legal move.
+ * @cssprop [--hexchess-possible-move-bg=#e4c7b7]            - The fill color of the small dot shown on a hexagon indicating this is a legal move.
+ * @cssprop [--hexchess-possible-capture-bg=#e4c7b7]         - The stroke color of the large circle outlining a piece that can be captured.
  * @cssprop [--hexchess-attempted-move-white-stroke=#e4c7b7] - The outline color of a hexagon when the user drags over a white square, trying to move there.
  * @cssprop [--hexchess-attempted-move-grey-stroke=#e4c7b7]  - The outline color of a hexagon when the user drags over a grey square, trying to move there.
  * @cssprop [--hexchess-attempted-move-black-stroke=#e4c7b7] - The outline color of a hexagon when the user drags over a black square, trying to move there.

--- a/src/hexchess-styles.ts
+++ b/src/hexchess-styles.ts
@@ -95,13 +95,13 @@ export const styles = css`
   }
 
   polygon.possible-move-white {
-    stroke: var(--hexchess-possible-move-stroke-white, #e4c7b7);
+    stroke: var(--hexchess-possible-move-stroke-white, #a96a41);
   }
   polygon.possible-move-black {
-    stroke: var(--hexchess-possible-move-stroke-black, #e4c7b7);
+    stroke: var(--hexchess-possible-move-stroke-black, #a96a41);
   }
   polygon.possible-move-grey {
-    stroke: var(--hexchess-possible-move-stroke-grey, #e4c7b7);
+    stroke: var(--hexchess-possible-move-stroke-grey, #a96a41);
   }
 
   .score {
@@ -125,21 +125,21 @@ export const styles = css`
     fill: var(--hexchess-white-bg, #a5c8df);
   }
   .selected .white {
-    fill: var(--hexchess-selected-white-bg, #a96a41);
+    fill: var(--hexchess-selected-white-bg, #e4c7b7);
   }
 
   .black {
     fill: var(--hexchess-black-bg, #4180a9);
   }
   .selected .black {
-    fill: var(--hexchess-selected-black-bg, #a96a41);
+    fill: var(--hexchess-selected-black-bg, #e4c7b7);
   }
 
   .grey {
     fill: var(--hexchess-grey-bg, #80b1d0);
   }
   .selected .grey {
-    fill: var(--hexchess-selected-grey-bg, #a96a41);
+    fill: var(--hexchess-selected-grey-bg, #e4c7b7);
   }
 
   .possible-move {


### PR DESCRIPTION
|Before|After|
|:----:|:-----:|
|<img width="613" alt="image" src="https://github.com/hexagonchess/hexchess-board/assets/48705139/b1791643-59bc-47a0-a313-912579105602">|<img width="963" alt="image" src="https://github.com/hexagonchess/hexchess-board/assets/48705139/cc842819-7d52-4e7e-807a-c057e07e89c0">|