### PR TITLE
Fix promotion overlay position fix for black

### DIFF
--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -616,7 +616,8 @@ export class HexchessBoard extends LitElement {
     const column = square[0] as Column;
     const isWhite = this._state.game.turn % 2 === 0;
     const isTop =
-      this._state.game.turn % 2 === 0 && this.orientation === 'white';
+      (this._state.game.turn % 2 === 0 && this.orientation === 'white') ||
+      (this._state.game.turn % 2 === 1 && this.orientation === 'black');
     const x = this._columnConfig[column].x;
     const y = isTop
       ? this._columnConfig[column].y

--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -614,13 +614,23 @@ export class HexchessBoard extends LitElement {
 
     const square = this._state.moves[this._state.moves.length - 1].to;
     const column = square[0] as Column;
+    const isWhite = this._state.game.turn % 2 === 0;
+    const isTop =
+      this._state.game.turn % 2 === 0 && this.orientation === 'white';
     const x = this._columnConfig[column].x;
-    const y = this._columnConfig[column].y;
+    const y = isTop
+      ? this._columnConfig[column].y
+      : this._columnConfig[column].y +
+        this._polygonHeight * (this._numberOfHexagons(column) - 4);
 
     const options: Piece[] =
-      this._state.game.turn % 2 === 0
+      isWhite && isTop
         ? ['Q', 'R', 'B', 'N']
-        : ['q', 'r', 'b', 'n'];
+        : isWhite && !isTop
+        ? ['N', 'B', 'R', 'Q']
+        : !isWhite && isTop
+        ? ['q', 'r', 'b', 'n']
+        : ['n', 'b', 'r', 'q'];
 
     return html`
       <div class="promotion" style="top: ${y}px; left: ${x}px;">


### PR DESCRIPTION
Fix the alignment for black promotion as well as when the orientation is flipped. Fixes #9 

Black promotion, bottom orientation:

https://github.com/hexagonchess/hexchess-board/assets/48705139/e38aa6d7-6324-42f0-b1ad-22db202a681e

Black promotion, top orientation:

https://github.com/hexagonchess/hexchess-board/assets/48705139/ffe53c0b-9907-4d0d-912f-ac92aec94390

White promotion, top orientation:

https://github.com/hexagonchess/hexchess-board/assets/48705139/5f169bd4-dd54-4380-bdef-c19089595042

White promotion, bottom orientation:

https://github.com/hexagonchess/hexchess-board/assets/48705139/31c3e71c-36c5-4a73-9267-b1cff5b11fa9
