### PR TITLE
Fix board not taking up entire space on Safari

### DIFF
--- a/src/hexchess-styles.ts
+++ b/src/hexchess-styles.ts
@@ -2,6 +2,9 @@ import {css} from 'lit';
 
 export const styles = css`
   :host {
+    display: block;
+    height: 100%;
+    width: 100%;
     font-family: var(
       --hexchess-font,
       -apple-system,


### PR DESCRIPTION
|Before|After|
|:-----:|:----:|
|![CleanShot 2024-02-03 at 10 59 01](https://github.com/hexagonchess/hexchess-board/assets/48705139/a2799381-7bd1-4324-9d59-dbb0edc30b05)|![CleanShot 2024-02-03 at 10 58 18](https://github.com/hexagonchess/hexchess-board/assets/48705139/595ddc3f-4eb9-4c67-8d36-c782c2321b9f)|

Fixes #1 