### PR TITLE
Add gameover event and player-role prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Read the full documentation on [the website](https://mganjoo.github.io/gchessboa
 
 ## Installing
 
-`gchessboard` is packaged as a [Web Component](https://developer.mozilla.org/en-US/docs/Web/Web_Components) and should be usable directly in most modern browsers. It bundles its own (configurable) styles, inline assets (for chess pieces), and code.
+`hexchess-board` is packaged as a [Web Component](https://developer.mozilla.org/en-US/docs/Web/Web_Components) and should be usable directly in most modern browsers. It bundles its own (configurable) styles, inline assets (for chess pieces), and code.
 
 #### In HTML (using unpkg)
 

--- a/docs-src/examples/player-roles.md
+++ b/docs-src/examples/player-roles.md
@@ -1,0 +1,59 @@
+---
+layout: page.11ty.cjs
+title: <hexchess-board> ⌲ Examples ⌲ Player Roles
+tags: example
+name: Player Roles
+description: Set player roles
+---
+
+<script src="https://unpkg.com/@webcomponents/webcomponentsjs@latest/webcomponents-loader.js"></script>
+<script type="module" src="https://esm.sh/@hexchess/hexchess-board@latest/hexchess-board.js?module"></script>
+
+<script>
+  document.addEventListener('keydown', (event) => {
+    event.preventDefault();
+  });
+  document.addEventListener('keyup', (event) => {
+    event.preventDefault();
+    if (event.code === 'KeyF') {
+      document.querySelector('hexchess-board').flip();
+    } else if (event.code === 'ArrowRight') {
+      document.querySelector('hexchess-board').fastForward();
+    } else if (event.code === 'ArrowLeft') {
+      document.querySelector('hexchess-board').rewind();
+    }
+  });
+  window.onload = () => {
+    document.querySelector('hexchess-board').resize();
+  };
+</script>
+
+In case you are using these boards in conjunction with a web server, you'll want to set player roles. With player roles, the current viewer of the board can be assigned to one of the following:
+
+* spectator - No mouse-based move operations will be allowed (but programmatic moves will still be allowed). This is intended to let spectators follow along with a game two others are playing
+
+* white - Only make moves when it is white's turn
+
+* black - Only make moves when it is black's turn
+
+* analysis - Make moves for both sides. Intended for local play (two players sharing the same device) or analyzing a set of moves played in a game. **This is the default.**
+
+```html
+<div style="width: 575px; height: 500px">
+  <hexchess-board
+    id="hexchess-board"
+    board="start"
+    orientation="white"
+    player-role="white"
+  ></hexchess-board>
+</div>
+```
+
+<div style="width: 575px; height: 500px">
+  <hexchess-board
+    id="hexchess-board"
+    board="start"
+    orientation="white"
+    player-role="white"
+  ></hexchess-board>
+</div>

--- a/docs-src/examples/preset-moves.md
+++ b/docs-src/examples/preset-moves.md
@@ -28,8 +28,6 @@ description: Analyzing a game that has a specific set of moves played.
   };
 </script>
 
-<h3>HTML</h3>
-
 Here we're building on the keyboard listener example, so you can use your left and right arrow keys to fast forward and rewind.
 
 Because Hexchess is much newer, we've decided to disambiguate the moves as much as possible. So while a king's pawn opening might be notated as `1. E4` followed by `1. E5`, in HexChess we want to show both the starting and the ending squares. So the white pawn moving from `B1` to `B3` would be notated as `B1-B3`.

--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -67,6 +67,14 @@ This is useful for analyzing games already played or certain pre-determined open
        </tr>
      
        <tr>
+         <td>player-role</td><td>The role of the player.
+If `white`, you can only make moves when it is white's turn.
+If `black`, you can only make moves when it is black's turn.
+If `spectator`, then you cannot make moves at all via the UI.
+If `analyzer`, then you can make moves for both sides, and it simuluates a local game.</td><td>Role</td><td>'analyzer'</td>
+       </tr>
+     
+       <tr>
          <td>hideCoordinates</td><td>Show the board coordinates on the bottom and left sides of the board.</td><td>boolean</td><td>false</td>
        </tr>
      
@@ -153,6 +161,10 @@ Usually called when the game is over.</td><td>void</td>
      
        <tr>
          <td>promoted</td><td>Fired when a pawn has been promoted to a piece.</td>
+       </tr>
+     
+       <tr>
+         <td>gameover</td><td>Fired when the game is over.</td>
        </tr>
      
        <tr>

--- a/docs/examples/change-look/index.html
+++ b/docs/examples/change-look/index.html
@@ -34,10 +34,6 @@
       <nav class="collection">
         <ul>
           
-                  <li class=>
-                    <a href="../">Common keyboard operations</a>
-                  </li>
-                
                   <li class=selected>
                     <a href="">Changing the look and feel of the board</a>
                   </li>
@@ -47,7 +43,15 @@
                   </li>
                 
                   <li class=>
+                    <a href="../">Common keyboard operations</a>
+                  </li>
+                
+                  <li class=>
                     <a href="../preset-moves/">Analyzing a game that has a specific set of moves played.</a>
+                  </li>
+                
+                  <li class=>
+                    <a href="../player-roles/">Set player roles</a>
                   </li>
                 
         </ul>

--- a/docs/examples/hexfen/index.html
+++ b/docs/examples/hexfen/index.html
@@ -35,10 +35,6 @@
         <ul>
           
                   <li class=>
-                    <a href="../">Common keyboard operations</a>
-                  </li>
-                
-                  <li class=>
                     <a href="../change-look/">Changing the look and feel of the board</a>
                   </li>
                 
@@ -47,7 +43,15 @@
                   </li>
                 
                   <li class=>
+                    <a href="../">Common keyboard operations</a>
+                  </li>
+                
+                  <li class=>
                     <a href="../preset-moves/">Analyzing a game that has a specific set of moves played.</a>
+                  </li>
+                
+                  <li class=>
+                    <a href="../player-roles/">Set player roles</a>
                   </li>
                 
         </ul>

--- a/docs/examples/index.html
+++ b/docs/examples/index.html
@@ -34,10 +34,6 @@
       <nav class="collection">
         <ul>
           
-                  <li class=selected>
-                    <a href="">Common keyboard operations</a>
-                  </li>
-                
                   <li class=>
                     <a href="change-look/">Changing the look and feel of the board</a>
                   </li>
@@ -46,8 +42,16 @@
                     <a href="hexfen/">Customizing the board layout with Hex-FEN</a>
                   </li>
                 
+                  <li class=selected>
+                    <a href="">Common keyboard operations</a>
+                  </li>
+                
                   <li class=>
                     <a href="preset-moves/">Analyzing a game that has a specific set of moves played.</a>
+                  </li>
+                
+                  <li class=>
+                    <a href="player-roles/">Set player roles</a>
                   </li>
                 
         </ul>

--- a/docs/examples/player-roles/index.html
+++ b/docs/examples/player-roles/index.html
@@ -1,0 +1,86 @@
+
+<!doctype html>
+
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><hexchess-board> ⌲ Examples ⌲ Player Roles</title>
+    <link rel="stylesheet" href="../../docs.css">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600|Roboto+Mono">
+    <link href="../../prism-okaidia.css" rel="stylesheet" />
+    <script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="/node_modules/lit/polyfill-support.js"></script>
+    <script type="module" src="../../hexchess-board.bundled.js"></script>
+  </head>
+  <body>
+    
+<header>
+  <h1>&lt;hexchess-board></h1>
+  <h2>Chess is better with hexagons</h2>
+</header>
+    
+<nav>
+  <a href="../../">Home</a>
+  <a href="../">Examples</a>
+  <a href="../../api/">API</a>
+  <a href="../../install/">Install</a>
+</nav>
+    <div id="main-wrapper">
+      <main>
+        <script src="https://unpkg.com/@webcomponents/webcomponentsjs@latest/webcomponents-loader.js"></script>
+<script type="module" src="https://esm.sh/@hexchess/hexchess-board@latest/hexchess-board.js?module"></script>
+<script>
+  document.addEventListener('keydown', (event) => {
+    event.preventDefault();
+  });
+  document.addEventListener('keyup', (event) => {
+    event.preventDefault();
+    if (event.code === 'KeyF') {
+      document.querySelector('hexchess-board').flip();
+    } else if (event.code === 'ArrowRight') {
+      document.querySelector('hexchess-board').fastForward();
+    } else if (event.code === 'ArrowLeft') {
+      document.querySelector('hexchess-board').rewind();
+    }
+  });
+  window.onload = () => {
+    document.querySelector('hexchess-board').resize();
+  };
+</script>
+<p>In case you are using these boards in conjunction with a web server, you'll want to set player roles. With player roles, the current viewer of the board can be assigned to one of the following:</p>
+<ul>
+<li>
+<p>spectator - No mouse-based move operations will be allowed (but programmatic moves will still be allowed). This is intended to let spectators follow along with a game two others are playing</p>
+</li>
+<li>
+<p>white - Only make moves when it is white's turn</p>
+</li>
+<li>
+<p>black - Only make moves when it is black's turn</p>
+</li>
+<li>
+<p>analysis - Make moves for both sides. Intended for local play (two players sharing the same device) or analyzing a set of moves played in a game. <strong>This is the default.</strong></p>
+</li>
+</ul>
+<pre class="language-html"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>div</span> <span class="token special-attr"><span class="token attr-name">style</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span><span class="token value css language-css"><span class="token property">width</span><span class="token punctuation">:</span> 575px<span class="token punctuation">;</span> <span class="token property">height</span><span class="token punctuation">:</span> 500px</span><span class="token punctuation">"</span></span></span><span class="token punctuation">></span></span><br>  <span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>hexchess-board</span><br>    <span class="token attr-name">id</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>hexchess-board<span class="token punctuation">"</span></span><br>    <span class="token attr-name">board</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>start<span class="token punctuation">"</span></span><br>    <span class="token attr-name">orientation</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>white<span class="token punctuation">"</span></span><br>    <span class="token attr-name">player-role</span><span class="token attr-value"><span class="token punctuation attr-equals">=</span><span class="token punctuation">"</span>white<span class="token punctuation">"</span></span><br>  <span class="token punctuation">></span></span><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>hexchess-board</span><span class="token punctuation">></span></span><br><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>div</span><span class="token punctuation">></span></span></code></pre>
+<div style="width: 575px; height: 500px">
+  <hexchess-board
+    id="hexchess-board"
+    board="start"
+    orientation="white"
+    player-role="white"
+  ></hexchess-board>
+</div>
+
+      </main>
+    </div>
+    
+<footer>
+  <p>
+    Made with
+    <a href="https://github.com/lit/lit-element-starter-ts">lit-starter-ts</a>
+  </p>
+</footer>
+  </body>
+</html>

--- a/docs/examples/preset-moves/index.html
+++ b/docs/examples/preset-moves/index.html
@@ -35,10 +35,6 @@
         <ul>
           
                   <li class=>
-                    <a href="../">Common keyboard operations</a>
-                  </li>
-                
-                  <li class=>
                     <a href="../change-look/">Changing the look and feel of the board</a>
                   </li>
                 
@@ -46,8 +42,16 @@
                     <a href="../hexfen/">Customizing the board layout with Hex-FEN</a>
                   </li>
                 
+                  <li class=>
+                    <a href="../">Common keyboard operations</a>
+                  </li>
+                
                   <li class=selected>
                     <a href="">Analyzing a game that has a specific set of moves played.</a>
+                  </li>
+                
+                  <li class=>
+                    <a href="../player-roles/">Set player roles</a>
                   </li>
                 
         </ul>
@@ -73,7 +77,6 @@
     document.querySelector('hexchess-board').resize();
   };
 </script>
-<h3>HTML</h3>
 <p>Here we're building on the keyboard listener example, so you can use your left and right arrow keys to fast forward and rewind.</p>
 <p>Because Hexchess is much newer, we've decided to disambiguate the moves as much as possible. So while a king's pawn opening might be notated as <code>1. E4</code> followed by <code>1. E5</code>, in HexChess we want to show both the starting and the ending squares. So the white pawn moving from <code>B1</code> to <code>B3</code> would be notated as <code>B1-B3</code>.</p>
 <p>To indicate a capture, we use the <code>x</code> instead of the <code>-</code> sign. Additionally, we add the piece to the end to specify what was captured. So if a white pawn on B4 captured a piece on C4, we would say <code>B4xC4p</code>.</p>
@@ -89,6 +92,7 @@
     moves="B1-B3,B7-B5,C2-C4,D7-D5,C4xD5p,F11xB3P,C1xC7p"
   ></hexchess-board>
 </div>
+
       </div>
     </section>
   

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,3 +35,5 @@ export interface HexchessPiece {
   defendedSquares(board: Board): Position[];
   toString(): Piece;
 }
+
+export type Role = 'white' | 'black' | 'spectator' | 'analyzer';


### PR DESCRIPTION
These are needed for a full client server interaction.

The gameover event firing lets the webpage optimistically update.

The player-role property lets servers disallow moving pieces when it's not the player's turn optimistically, rather than relying on the server to reject moves.