### PR TITLE
Add an overloaded move method that takes a single FEN string

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -139,6 +139,22 @@ Usually called when the game is over.</td><td>void</td>
      </tr>
      
        <tr>
+         <td>from</td><td></td><td>string</td>
+       </tr>
+     
+   </table>
+ </td><td>Make a move on the board.</td><td></td>
+       </tr>
+     
+       <tr>
+         <td>move</td><td>
+   
+   <table>
+     <tr>
+       <th>Name</th><th>Description</th><th>Type</th>
+     </tr>
+     
+       <tr>
          <td>from</td><td></td><td>Square</td>
        </tr>
      
@@ -147,7 +163,27 @@ Usually called when the game is over.</td><td>void</td>
        </tr>
      
    </table>
- </td><td>Make a move on the board.</td><td></td>
+ </td><td></td><td>boolean</td>
+       </tr>
+     
+       <tr>
+         <td>move</td><td>
+   
+   <table>
+     <tr>
+       <th>Name</th><th>Description</th><th>Type</th>
+     </tr>
+     
+       <tr>
+         <td>arg</td><td></td><td>string | Square</td>
+       </tr>
+     
+       <tr>
+         <td>to</td><td></td><td>Square</td>
+       </tr>
+     
+   </table>
+ </td><td></td><td>boolean</td>
        </tr>
      
        <tr>

--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -1251,15 +1251,46 @@ export class HexchessBoard extends LitElement {
    *
    * @returns Whether or not the move can be made.
    */
-  move(from: Square, to: Square): boolean {
+  move(from: string): boolean;
+  move(from: Square, to: Square): boolean;
+  move(arg: string | Square, to?: Square): boolean {
     // No moves if board is frozen
     if (this.frozen) {
       return false;
     }
 
+    if (typeof arg !== 'string') {
+      return false;
+    }
+
+    if (!ALL_SQUARES.includes(arg as any)) {
+      return false;
+    }
+
+    if (to === undefined) {
+      try {
+        const newMove = stringToMoves(arg);
+        if (newMove.length !== 1) {
+          return false;
+        }
+        const newState = getNewState(this._state, {
+          name: 'PROGRAMMATIC_MOVE',
+          move: [newMove[0].from, newMove[0].to],
+        });
+        this._reconcileNewState(newState);
+        return newState.didChange;
+      } catch (error) {
+        return false;
+      }
+    }
+
+    if (!ALL_SQUARES.includes(to as any)) {
+      return false;
+    }
+
     const newState = getNewState(this._state, {
       name: 'PROGRAMMATIC_MOVE',
-      move: [from, to],
+      move: [arg as Square, to as Square],
     });
     this._reconcileNewState(newState);
     return newState.didChange;


### PR DESCRIPTION
Enable the user to call either `.move(B1, B3)` or `.move(B1-B3)`