### PR TITLE
Enable showing hints for opponent piece moves

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -82,6 +82,10 @@ If `analyzer`, then you can make moves for both sides, and it simuluates a local
          <td>frozen</td><td>Do not allow any other moves beyond the predetermined ones set in the `moves` property.</td><td>boolean</td><td>false</td>
        </tr>
      
+       <tr>
+         <td>show-hints</td><td>Clicking on an opponent's piece shows all the squares it can move to</td><td>boolean</td><td>true</td>
+       </tr>
+     
    </table>
  
        

--- a/src/board-state.ts
+++ b/src/board-state.ts
@@ -20,6 +20,7 @@ export type MouseDownPieceSelected = {
   game: Game;
   capturedPieces: Partial<Record<Piece, number>>;
   legalMoves: LegalMoves;
+  opponentPieceMoves?: Square[];
   moves: Move[];
   name: 'MOUSE_DOWN_PIECE_SELECTED';
   scoreBlack: number;
@@ -31,6 +32,7 @@ export type MouseUpPieceSelected = {
   game: Game;
   capturedPieces: Partial<Record<Piece, number>>;
   legalMoves: LegalMoves;
+  opponentPieceMoves?: Square[];
   moves: Move[];
   name: 'MOUSE_UP_PIECE_SELECTED';
   scoreBlack: number;
@@ -43,6 +45,7 @@ export type DragPieceState = {
   capturedPieces: Partial<Record<Piece, number>>;
   dragSquare: Square;
   legalMoves: LegalMoves;
+  opponentPieceMoves?: Square[];
   moves: Move[];
   name: 'DRAG_PIECE';
   scoreBlack: number;
@@ -54,6 +57,7 @@ export type CancelSelectionSoonState = {
   game: Game;
   capturedPieces: Partial<Record<Piece, number>>;
   legalMoves: LegalMoves;
+  opponentPieceMoves?: Square[];
   moves: Move[];
   name: 'CANCEL_SELECTION_SOON';
   scoreBlack: number;
@@ -417,12 +421,19 @@ const _waitingStateTransition = (
       if (!piece) {
         return { state, didChange: false };
       }
+      const isOppositeColor =
+        (state.game.turn % 2 === 0 && piece.color === 'black') ||
+        (state.game.turn % 2 === 1 && piece.color === 'white');
+      const opponentPieceMoves = isOppositeColor
+        ? piece.allSquareMoves(state.game.board).map((move) => move.toSquare())
+        : undefined;
       return {
         state: {
           ...state,
           name: 'MOUSE_DOWN_PIECE_SELECTED',
           selectedPiece: piece.toString(),
           square: transition.square,
+          opponentPieceMoves,
         },
         didChange: true,
       };
@@ -516,12 +527,22 @@ const _mouseUpPieceSelectedStateTransition = (
       // 3. If it's an occupied piece, select the piece
       const piece = state.game.board.getPiece(transition.square);
       if (piece) {
+        const isOppositeColor =
+          (state.game.turn % 2 === 0 && piece.color === 'black') ||
+          (state.game.turn % 2 === 1 && piece.color === 'white');
+        const opponentPieceMoves = isOppositeColor
+          ? piece
+              .allSquareMoves(state.game.board)
+              .map((move) => move.toSquare())
+          : undefined;
+
         return {
           state: {
             ...state,
             name: 'MOUSE_DOWN_PIECE_SELECTED',
             selectedPiece: piece.toString(),
             square: transition.square,
+            opponentPieceMoves,
           },
           didChange: true,
         };

--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -205,6 +205,12 @@ export class HexchessBoard extends LitElement {
   @property({ type: Boolean })
   frozen = false;
 
+  /**
+   * Clicking on an opponent's piece shows all the squares it can move to
+   */
+  @property({ attribute: 'show-hints', type: Boolean })
+  showHints = true;
+
   constructor() {
     super();
     this._recalculateBoardCoordinates();
@@ -1080,7 +1086,11 @@ export class HexchessBoard extends LitElement {
     if (this._state.square === square) {
       return nothing;
     }
-    if (!this._state.legalMoves[this._state.square]?.has(square)) {
+    if (
+      (!this._state.opponentPieceMoves ||
+        !this._state.opponentPieceMoves.includes(square)) &&
+      !this._state.legalMoves[this._state.square]?.has(square)
+    ) {
       return nothing;
     }
 

--- a/src/hexchess-styles.ts
+++ b/src/hexchess-styles.ts
@@ -91,6 +91,7 @@ export const styles = css`
 
   .possible-move-grey,
   .possible-move-black,
+  .possible-move-opponent,
   .possible-move-white {
     stroke-width: 5;
     fill: none;
@@ -105,6 +106,9 @@ export const styles = css`
   }
   polygon.possible-move-grey {
     stroke: var(--hexchess-possible-move-stroke-grey, #a96a41);
+  }
+  polygon.possible-move-opponent {
+    stroke: var(--hexchess-possible-move-stroke-opponent, #e3e3e3);
   }
 
   .score {
@@ -122,6 +126,16 @@ export const styles = css`
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+  }
+
+  .selected-opponent .white {
+    fill: var(--hexchess-possible-move-opponent-bg, #e3e3e3);
+  }
+  .selected-opponent .black {
+    fill: var(--hexchess-possible-move-opponent-bg, #e3e3e3);
+  }
+  .selected-opponent .grey {
+    fill: var(--hexchess-possible-move-opponent-bg, #e3e3e3);
   }
 
   .white {
@@ -147,6 +161,10 @@ export const styles = css`
 
   .possible-move {
     fill: var(--hexchess-possible-move-bg, #a96a41);
+  }
+
+  .opponent-move {
+    fill: var(--hexchess-possible-move-opponent-bg, #e3e3e3);
   }
 
   .drag-piece {


### PR DESCRIPTION
Because hexchess is relatively new, it's hard for players to know where their opponents' pieces _might_ move.

With the `show-hints` flag enabled, clicking on an opponent's piece, even if it's not your turn, will display where that piece could move.

Note that it does NOT calculate potentially illegal moves, like moving a pinned piece, as it is technically not the opponent's turn. It merely shows all possible moves the piece could potentially do based on its movement pattern.