### PR TITLE
Emit furthestforward and furthestback custom events

### DIFF
--- a/docs/api/index.html
+++ b/docs/api/index.html
@@ -231,6 +231,14 @@ Usually called when the game is over.</td><td>void</td>
          <td>move</td><td>Fired when a move is made on the board.</td>
        </tr>
      
+       <tr>
+         <td>furthestback</td><td>Fired when the game is rewound to its starting position.</td>
+       </tr>
+     
+       <tr>
+         <td>furthestforward</td><td>Fired when a game is fast forwarded back to its current position.</td>
+       </tr>
+     
    </table>
      
          

--- a/src/board-state.ts
+++ b/src/board-state.ts
@@ -146,387 +146,302 @@ export type Transition =
       piece: Omit<Piece, 'K' | 'k' | 'P' | 'p'>;
     };
 
-export const getNewState = (
-  state: BoardState,
-  transition: Transition,
-): BoardChange => {
-  switch (state.name) {
-    case 'WAITING':
-      return _waitingStateTransition(state, transition);
-    case 'MOUSE_DOWN_PIECE_SELECTED':
-      return _mouseDownPieceSelectedStateTransition(state, transition);
-    case 'MOUSE_UP_PIECE_SELECTED':
-      return _mouseUpPieceSelectedStateTransition(state, transition);
-    case 'DRAG_PIECE':
-      return _dragPieceStateTransition(state, transition);
-    case 'CANCEL_SELECTION_SOON':
-      return _cancelSelectionSoonStateTransition(state, transition);
-    case 'REWOUND':
-      return _rewoundStateTransition(state, transition);
-    case 'PROMOTING':
-      return _promotingStateTransition(state, transition);
-    case 'GAMEOVER':
-      return { state, didChange: false };
-  }
-};
+export class BoardStateMachine {
+  private readonly emitFurthestBack: () => void;
+  private readonly emitFurthestForward: () => void;
 
-const _capturePieceOrMakeMove = (
-  state: WaitingState | MouseUpPieceSelected | DragPieceState,
-  from: Square,
-  to: Square,
-): BoardChange => {
-  const fromPiece = state.game.board.getPiece(from);
-  const toPiece = state.game.board.getPiece(to);
-  let capturedPiece: HexchessPiece | null;
-  let enPassant = false;
-  if (fromPiece instanceof Pawn && from[0] !== to[0] && !toPiece) {
-    enPassant = true;
-    const row = Number.parseInt(to.slice(1));
-    const capturedLocation =
-      fromPiece.color === 'white' ? `${to[0]}${row - 1}` : `${to[0]}${row + 1}`;
-    capturedPiece = state.game.board.getPiece(capturedLocation as Square);
-  } else {
-    capturedPiece = state.game.board.getPiece(to);
+  constructor(furthestBack: () => void, furthestForward: () => void) {
+    this.emitFurthestBack = furthestBack;
+    this.emitFurthestForward = furthestForward;
   }
 
-  const newMove = {
-    from,
-    to,
-    capturedPiece: capturedPiece ? capturedPiece.toString() : undefined,
-    enPassant,
-    promotion: null,
+  getNewState = (state: BoardState, transition: Transition): BoardChange => {
+    switch (state.name) {
+      case 'WAITING':
+        return this._waitingStateTransition(state, transition);
+      case 'MOUSE_DOWN_PIECE_SELECTED':
+        return this._mouseDownPieceSelectedStateTransition(state, transition);
+      case 'MOUSE_UP_PIECE_SELECTED':
+        return this._mouseUpPieceSelectedStateTransition(state, transition);
+      case 'DRAG_PIECE':
+        return this._dragPieceStateTransition(state, transition);
+      case 'CANCEL_SELECTION_SOON':
+        return this._cancelSelectionSoonStateTransition(state, transition);
+      case 'REWOUND':
+        return this._rewoundStateTransition(state, transition);
+      case 'PROMOTING':
+        return this._promotingStateTransition(state, transition);
+      case 'GAMEOVER':
+        return { state, didChange: false };
+    }
   };
-  const newWhiteScore =
-    capturedPiece?.color === 'white'
-      ? state.scoreWhite - PIECE_VALUES[capturedPiece?.toString()]
-      : state.scoreWhite;
-  const newBlackScore =
-    capturedPiece?.color === 'black'
-      ? state.scoreBlack - PIECE_VALUES[capturedPiece?.toString()]
-      : state.scoreBlack;
-  state.game.movePiece(Position.fromString(from), Position.fromString(to));
-  let newCapturedPieces: Partial<Record<Piece, number>>;
-  if (!capturedPiece) {
-    newCapturedPieces = state.capturedPieces;
-  } else {
-    const capturedPieceAsString = capturedPiece.toString();
-    newCapturedPieces = JSON.parse(JSON.stringify(state.capturedPieces));
-    if (capturedPiece.toString() in newCapturedPieces) {
-      const capturedPieces = newCapturedPieces[capturedPieceAsString];
-      if (capturedPieces == null) {
-        throw new Error('This is impossible');
-      }
-      newCapturedPieces[capturedPieceAsString] = capturedPieces + 1;
+
+  private _capturePieceOrMakeMove = (
+    state: WaitingState | MouseUpPieceSelected | DragPieceState,
+    from: Square,
+    to: Square,
+  ): BoardChange => {
+    const fromPiece = state.game.board.getPiece(from);
+    const toPiece = state.game.board.getPiece(to);
+    let capturedPiece: HexchessPiece | null;
+    let enPassant = false;
+    if (fromPiece instanceof Pawn && from[0] !== to[0] && !toPiece) {
+      enPassant = true;
+      const row = Number.parseInt(to.slice(1));
+      const capturedLocation =
+        fromPiece.color === 'white'
+          ? `${to[0]}${row - 1}`
+          : `${to[0]}${row + 1}`;
+      capturedPiece = state.game.board.getPiece(capturedLocation as Square);
     } else {
-      newCapturedPieces[capturedPieceAsString] = 1;
+      capturedPiece = state.game.board.getPiece(to);
     }
-  }
 
-  if (
-    state.game.state() !== GameState.IN_PROGRESS &&
-    state.game.state() !== GameState.PROMOTING
-  ) {
-    let outcome: Outcome = 'DRAW';
-    if (state.game.state() === GameState.CHECKMATE) {
-      outcome = state.game.turn % 2 === 0 ? 'BLACK_WINS' : 'WHITE_WINS';
-    }
-    return {
-      state: {
-        ...state,
-        capturedPieces: newCapturedPieces,
-        moves: state.moves.concat(newMove),
-        name: 'GAMEOVER',
-        outcome,
-        scoreBlack: newBlackScore,
-        scoreWhite: newWhiteScore,
-      },
-      didChange: true,
+    const newMove = {
+      from,
+      to,
+      capturedPiece: capturedPiece ? capturedPiece.toString() : undefined,
+      enPassant,
+      promotion: null,
     };
-  }
-  if (
-    fromPiece instanceof Pawn &&
-    (Position.fromString(to).isBeginningOfColumn() ||
-      Position.fromString(to).isEndOfColumn())
-  ) {
-    return {
-      state: {
-        ...state,
-        capturedPieces: newCapturedPieces,
-        moves: state.moves.concat(newMove),
-        name: 'PROMOTING',
-        scoreBlack: newBlackScore,
-        scoreWhite: newWhiteScore,
-      },
-      didChange: true,
-    };
-  }
-  return {
-    state: {
-      ...state,
-      capturedPieces: newCapturedPieces,
-      legalMoves: state.game.allLegalMoves(),
-      moves: state.moves.concat(newMove),
-      name: 'WAITING',
-      scoreBlack: newBlackScore,
-      scoreWhite: newWhiteScore,
-    },
-    didChange: true,
-  };
-};
-
-const _promotingStateTransition = (
-  state: PromotionState,
-  transition: Transition,
-): BoardChange => {
-  switch (transition.name) {
-    case 'PROMOTE': {
-      const isWhite = state.game.turn % 2 === 0;
-      let scoreBump: number;
-      switch (transition.piece) {
-        case 'Q':
-        case 'q':
-          scoreBump = 8;
-          break;
-        case 'R':
-        case 'r':
-          scoreBump = 4;
-          break;
-        default:
-          scoreBump = 2;
-          break;
-      }
-      state.game.promotePawn(transition.piece);
-      const newCapturedPieces = JSON.parse(
-        JSON.stringify(state.capturedPieces),
-      );
-      if (isWhite) {
-        if (!newCapturedPieces.P) {
-          newCapturedPieces.P = 1;
-        } else {
-          newCapturedPieces.P += 1;
+    const newWhiteScore =
+      capturedPiece?.color === 'white'
+        ? state.scoreWhite - PIECE_VALUES[capturedPiece?.toString()]
+        : state.scoreWhite;
+    const newBlackScore =
+      capturedPiece?.color === 'black'
+        ? state.scoreBlack - PIECE_VALUES[capturedPiece?.toString()]
+        : state.scoreBlack;
+    state.game.movePiece(Position.fromString(from), Position.fromString(to));
+    let newCapturedPieces: Partial<Record<Piece, number>>;
+    if (!capturedPiece) {
+      newCapturedPieces = state.capturedPieces;
+    } else {
+      const capturedPieceAsString = capturedPiece.toString();
+      newCapturedPieces = JSON.parse(JSON.stringify(state.capturedPieces));
+      if (capturedPiece.toString() in newCapturedPieces) {
+        const capturedPieces = newCapturedPieces[capturedPieceAsString];
+        if (capturedPieces == null) {
+          throw new Error('This is impossible');
         }
-        if (!newCapturedPieces[transition.piece.toLowerCase()]) {
-          newCapturedPieces[transition.piece.toLowerCase()] = 1;
-        } else {
-          newCapturedPieces[transition.piece.toLowerCase()] += 1;
-        }
+        newCapturedPieces[capturedPieceAsString] = capturedPieces + 1;
       } else {
-        if (!newCapturedPieces.p) {
-          newCapturedPieces.p = 1;
-        } else {
-          newCapturedPieces.p += 1;
-        }
-        if (!newCapturedPieces[transition.piece.toUpperCase()]) {
-          newCapturedPieces[transition.piece.toUpperCase()] = 1;
-        } else {
-          newCapturedPieces[transition.piece.toUpperCase()] += 1;
-        }
+        newCapturedPieces[capturedPieceAsString] = 1;
       }
-      state.moves[state.moves.length - 1].promotion = transition.piece;
+    }
+
+    if (
+      state.game.state() !== GameState.IN_PROGRESS &&
+      state.game.state() !== GameState.PROMOTING
+    ) {
+      let outcome: Outcome = 'DRAW';
+      if (state.game.state() === GameState.CHECKMATE) {
+        outcome = state.game.turn % 2 === 0 ? 'BLACK_WINS' : 'WHITE_WINS';
+      }
       return {
-        didChange: true,
         state: {
           ...state,
           capturedPieces: newCapturedPieces,
-          legalMoves: state.game.allLegalMoves(),
-          name: 'WAITING',
-          scoreBlack: !isWhite
-            ? state.scoreBlack + scoreBump
-            : state.scoreBlack,
-          scoreWhite: isWhite ? state.scoreWhite + scoreBump : state.scoreWhite,
+          moves: state.moves.concat(newMove),
+          name: 'GAMEOVER',
+          outcome,
+          scoreBlack: newBlackScore,
+          scoreWhite: newWhiteScore,
         },
+        didChange: true,
       };
     }
-    default: {
+    if (
+      fromPiece instanceof Pawn &&
+      (Position.fromString(to).isBeginningOfColumn() ||
+        Position.fromString(to).isEndOfColumn())
+    ) {
       return {
-        didChange: false,
-        state,
+        state: {
+          ...state,
+          capturedPieces: newCapturedPieces,
+          moves: state.moves.concat(newMove),
+          name: 'PROMOTING',
+          scoreBlack: newBlackScore,
+          scoreWhite: newWhiteScore,
+        },
+        didChange: true,
       };
     }
-  }
-};
+    return {
+      state: {
+        ...state,
+        capturedPieces: newCapturedPieces,
+        legalMoves: state.game.allLegalMoves(),
+        moves: state.moves.concat(newMove),
+        name: 'WAITING',
+        scoreBlack: newBlackScore,
+        scoreWhite: newWhiteScore,
+      },
+      didChange: true,
+    };
+  };
 
-const _rewoundStateTransition = (
-  state: RewoundState,
-  transition: Transition,
-): BoardChange => {
-  switch (transition.name) {
-    case 'FAST_FORWARD': {
-      if (state.currentTurn === state.game.turn) {
-        return { state, didChange: false };
-      }
-      const move = state.moves[state.currentTurn];
-      state.game.fastForward(move);
-      let newName: BoardState['name'];
-      if (state.currentTurn === state.game.turn - 1) {
-        newName =
-          state.game.state() === GameState.PROMOTING ? 'PROMOTING' : 'WAITING';
-      } else {
-        newName = 'REWOUND';
-      }
-      return {
-        state: {
-          ...state,
-          currentTurn: state.currentTurn + 1,
-          name: newName,
-        },
-        didChange: true,
-      };
-    }
-    case 'REWIND': {
-      if (state.currentTurn === 0) {
-        return { state, didChange: false };
-      }
-      const move = state.moves[state.currentTurn - 1];
-      state.game.rewind(move);
-      return {
-        state: {
-          ...state,
-          currentTurn: state.currentTurn - 1,
-          name: 'REWOUND',
-        },
-        didChange: true,
-      };
-    }
-    default:
-      return { state, didChange: false };
-  }
-};
-
-const _waitingStateTransition = (
-  state: WaitingState,
-  transition: Transition,
-): BoardChange => {
-  switch (transition.name) {
-    case 'REWIND': {
-      if (state.game.turn === 0) {
-        return { state, didChange: false };
-      }
-      const move = state.moves[state.game.turn - 1];
-      state.game.rewind(move);
-      return {
-        state: {
-          ...state,
-          currentTurn: state.game.turn - 1,
-          name: 'REWOUND',
-        },
-        didChange: true,
-      };
-    }
-    case 'MOUSE_DOWN': {
-      if (!(transition.square in state.game.board.pieces)) {
-        return { state, didChange: false };
-      }
-      const piece = state.game.board.getPiece(transition.square);
-      if (!piece) {
-        return { state, didChange: false };
-      }
-      const isOppositeColor =
-        (state.game.turn % 2 === 0 && piece.color === 'black') ||
-        (state.game.turn % 2 === 1 && piece.color === 'white');
-      const opponentPieceMoves = isOppositeColor
-        ? piece.allSquareMoves(state.game.board).map((move) => move.toSquare())
-        : undefined;
-      return {
-        state: {
-          ...state,
-          name: 'MOUSE_DOWN_PIECE_SELECTED',
-          selectedPiece: piece.toString(),
-          square: transition.square,
-          opponentPieceMoves,
-        },
-        didChange: true,
-      };
-    }
-    case 'PROGRAMMATIC_MOVE': {
-      const from = transition.move[0];
-      const to = transition.move[1];
-      if (!(from in state.game.board.pieces)) {
-        return { state, didChange: false };
-      }
-      const piece = state.game.board.getPiece(from);
-      if (!piece) {
-        return { state, didChange: false };
-      }
-
-      if (!state.legalMoves[from]?.has(to)) {
-        return { state, didChange: false };
-      }
-
-      return _capturePieceOrMakeMove(state, from, to);
-    }
-    default:
-      return { state, didChange: false };
-  }
-};
-
-const _mouseDownPieceSelectedStateTransition = (
-  state: MouseDownPieceSelected,
-  transition: Transition,
-): BoardChange => {
-  switch (transition.name) {
-    case 'MOUSE_MOVE_OUTSIDE_BOARD':
-      return {
-        state: {
-          ...state,
-          dragSquare: state.square,
-          name: 'DRAG_PIECE',
-        },
-        didChange: true,
-      };
-    case 'MOUSE_MOVE_SQUARE':
-      return {
-        state: {
-          ...state,
-          dragSquare: transition.square,
-          name: 'DRAG_PIECE',
-        },
-        didChange: true,
-      };
-    case 'MOUSE_UP':
-      return {
-        state: {
-          ...state,
-          name: 'MOUSE_UP_PIECE_SELECTED',
-        },
-        didChange: true,
-      };
-    default:
-      return { state, didChange: false };
-  }
-};
-
-const _mouseUpPieceSelectedStateTransition = (
-  state: MouseUpPieceSelected,
-  transition: Transition,
-): BoardChange => {
-  switch (transition.name) {
-    case 'MOUSE_DOWN': {
-      if (!(transition.square in state.game.board.pieces)) {
-        throw new Error(
-          'Square must be in board - did you mean MOUSE_DOWN_OUTSIDE_BOARD transition?',
+  private _promotingStateTransition = (
+    state: PromotionState,
+    transition: Transition,
+  ): BoardChange => {
+    switch (transition.name) {
+      case 'PROMOTE': {
+        const isWhite = state.game.turn % 2 === 0;
+        let scoreBump: number;
+        switch (transition.piece) {
+          case 'Q':
+          case 'q':
+            scoreBump = 8;
+            break;
+          case 'R':
+          case 'r':
+            scoreBump = 4;
+            break;
+          default:
+            scoreBump = 2;
+            break;
+        }
+        state.game.promotePawn(transition.piece);
+        const newCapturedPieces = JSON.parse(
+          JSON.stringify(state.capturedPieces),
         );
+        if (isWhite) {
+          if (!newCapturedPieces.P) {
+            newCapturedPieces.P = 1;
+          } else {
+            newCapturedPieces.P += 1;
+          }
+          if (!newCapturedPieces[transition.piece.toLowerCase()]) {
+            newCapturedPieces[transition.piece.toLowerCase()] = 1;
+          } else {
+            newCapturedPieces[transition.piece.toLowerCase()] += 1;
+          }
+        } else {
+          if (!newCapturedPieces.p) {
+            newCapturedPieces.p = 1;
+          } else {
+            newCapturedPieces.p += 1;
+          }
+          if (!newCapturedPieces[transition.piece.toUpperCase()]) {
+            newCapturedPieces[transition.piece.toUpperCase()] = 1;
+          } else {
+            newCapturedPieces[transition.piece.toUpperCase()] += 1;
+          }
+        }
+        state.moves[state.moves.length - 1].promotion = transition.piece;
+        return {
+          didChange: true,
+          state: {
+            ...state,
+            capturedPieces: newCapturedPieces,
+            legalMoves: state.game.allLegalMoves(),
+            name: 'WAITING',
+            scoreBlack: !isWhite
+              ? state.scoreBlack + scoreBump
+              : state.scoreBlack,
+            scoreWhite: isWhite
+              ? state.scoreWhite + scoreBump
+              : state.scoreWhite,
+          },
+        };
       }
+      default: {
+        return {
+          didChange: false,
+          state,
+        };
+      }
+    }
+  };
 
-      // 1. If occupied square, and it's the same piece, go to cancel selection soon
-      if (state.square === transition.square) {
+  private _rewoundStateTransition = (
+    state: RewoundState,
+    transition: Transition,
+  ): BoardChange => {
+    switch (transition.name) {
+      case 'FAST_FORWARD': {
+        if (state.currentTurn === state.game.turn) {
+          return { state, didChange: false };
+        }
+        const move = state.moves[state.currentTurn];
+        state.game.fastForward(move);
+        let newName: BoardState['name'];
+        if (state.currentTurn === state.game.turn - 1) {
+          newName =
+            state.game.state() === GameState.PROMOTING
+              ? 'PROMOTING'
+              : 'WAITING';
+          this.emitFurthestForward();
+        } else {
+          newName = 'REWOUND';
+        }
         return {
           state: {
             ...state,
-            name: 'CANCEL_SELECTION_SOON',
+            currentTurn: state.currentTurn + 1,
+            name: newName,
           },
           didChange: true,
         };
       }
-
-      // 2. If it's a legal move, make the move
-      if (state.legalMoves[state.square]?.has(transition.square)) {
-        return _capturePieceOrMakeMove(state, state.square, transition.square);
+      case 'REWIND': {
+        if (state.currentTurn === 0) {
+          this.emitFurthestBack();
+          return { state, didChange: false };
+        }
+        if (state.currentTurn === 1) {
+          this.emitFurthestBack();
+        }
+        const move = state.moves[state.currentTurn - 1];
+        state.game.rewind(move);
+        return {
+          state: {
+            ...state,
+            currentTurn: state.currentTurn - 1,
+            name: 'REWOUND',
+          },
+          didChange: true,
+        };
       }
+      default:
+        return { state, didChange: false };
+    }
+  };
 
-      // 3. If it's an occupied piece, select the piece
-      const piece = state.game.board.getPiece(transition.square);
-      if (piece) {
+  private _waitingStateTransition = (
+    state: WaitingState,
+    transition: Transition,
+  ): BoardChange => {
+    switch (transition.name) {
+      case 'REWIND': {
+        if (state.game.turn === 0) {
+          this.emitFurthestBack();
+          return { state, didChange: false };
+        }
+        const move = state.moves[state.game.turn - 1];
+        state.game.rewind(move);
+        if (state.game.turn === 1) {
+          this.emitFurthestBack();
+        }
+        return {
+          state: {
+            ...state,
+            currentTurn: state.game.turn - 1,
+            name: 'REWOUND',
+          },
+          didChange: true,
+        };
+      }
+      case 'MOUSE_DOWN': {
+        if (!(transition.square in state.game.board.pieces)) {
+          return { state, didChange: false };
+        }
+        const piece = state.game.board.getPiece(transition.square);
+        if (!piece) {
+          return { state, didChange: false };
+        }
         const isOppositeColor =
           (state.game.turn % 2 === 0 && piece.color === 'black') ||
           (state.game.turn % 2 === 1 && piece.color === 'white');
@@ -535,7 +450,6 @@ const _mouseUpPieceSelectedStateTransition = (
               .allSquareMoves(state.game.board)
               .map((move) => move.toSquare())
           : undefined;
-
         return {
           state: {
             ...state,
@@ -547,57 +461,52 @@ const _mouseUpPieceSelectedStateTransition = (
           didChange: true,
         };
       }
+      case 'PROGRAMMATIC_MOVE': {
+        const from = transition.move[0];
+        const to = transition.move[1];
+        if (!(from in state.game.board.pieces)) {
+          return { state, didChange: false };
+        }
+        const piece = state.game.board.getPiece(from);
+        if (!piece) {
+          return { state, didChange: false };
+        }
 
-      // 4. Otherwise go back to waiting
-      return {
-        state: {
-          ...state,
-          name: 'WAITING',
-        },
-        didChange: true,
-      };
+        if (!state.legalMoves[from]?.has(to)) {
+          return { state, didChange: false };
+        }
+
+        return this._capturePieceOrMakeMove(state, from, to);
+      }
+      default:
+        return { state, didChange: false };
     }
-    case 'MOUSE_DOWN_OUTSIDE_BOARD':
-      return {
-        state: {
-          ...state,
-          name: 'WAITING',
-        },
-        didChange: true,
-      };
-    default:
-      return { state, didChange: false };
-  }
-};
+  };
 
-const _dragPieceStateTransition = (
-  state: DragPieceState,
-  transition: Transition,
-): BoardChange => {
-  switch (transition.name) {
-    case 'MOUSE_MOVE_OUTSIDE_BOARD':
-      return {
-        state,
-        didChange: false,
-      };
-    case 'MOUSE_MOVE_SQUARE':
-      return {
-        state: {
-          ...state,
-          dragSquare: transition.square,
-        },
-        didChange: true,
-      };
-    case 'MOUSE_UP_OUTSIDE_BOARD':
-      return {
-        state: {
-          ...state,
-          name: 'MOUSE_UP_PIECE_SELECTED',
-        },
-        didChange: true,
-      };
-    case 'MOUSE_UP': {
-      if (!state.legalMoves[state.square]?.has(transition.square)) {
+  private _mouseDownPieceSelectedStateTransition = (
+    state: MouseDownPieceSelected,
+    transition: Transition,
+  ): BoardChange => {
+    switch (transition.name) {
+      case 'MOUSE_MOVE_OUTSIDE_BOARD':
+        return {
+          state: {
+            ...state,
+            dragSquare: state.square,
+            name: 'DRAG_PIECE',
+          },
+          didChange: true,
+        };
+      case 'MOUSE_MOVE_SQUARE':
+        return {
+          state: {
+            ...state,
+            dragSquare: transition.square,
+            name: 'DRAG_PIECE',
+          },
+          didChange: true,
+        };
+      case 'MOUSE_UP':
         return {
           state: {
             ...state,
@@ -605,46 +514,169 @@ const _dragPieceStateTransition = (
           },
           didChange: true,
         };
-      }
-      return _capturePieceOrMakeMove(state, state.square, transition.square);
+      default:
+        return { state, didChange: false };
     }
-    default:
-      return { state, didChange: false };
-  }
-};
+  };
 
-const _cancelSelectionSoonStateTransition = (
-  state: CancelSelectionSoonState,
-  transition: Transition,
-): BoardChange => {
-  switch (transition.name) {
-    case 'MOUSE_MOVE_OUTSIDE_BOARD':
-      return {
-        state: {
-          ...state,
-          name: 'DRAG_PIECE',
-          dragSquare: state.square,
-        },
-        didChange: true,
-      };
-    case 'MOUSE_MOVE_SQUARE':
-      return {
-        state: {
-          ...state,
-          name: 'DRAG_PIECE',
-          dragSquare: transition.square,
-        },
-        didChange: true,
-      };
-    case 'MOUSE_UP':
-      return {
-        state: {
-          ...state,
-          name: 'WAITING',
-        },
-        didChange: true,
-      };
-    default:
-      return { state, didChange: false };
-  }
-};
+  private _mouseUpPieceSelectedStateTransition = (
+    state: MouseUpPieceSelected,
+    transition: Transition,
+  ): BoardChange => {
+    switch (transition.name) {
+      case 'MOUSE_DOWN': {
+        if (!(transition.square in state.game.board.pieces)) {
+          throw new Error(
+            'Square must be in board - did you mean MOUSE_DOWN_OUTSIDE_BOARD transition?',
+          );
+        }
+
+        // 1. If occupied square, and it's the same piece, go to cancel selection soon
+        if (state.square === transition.square) {
+          return {
+            state: {
+              ...state,
+              name: 'CANCEL_SELECTION_SOON',
+            },
+            didChange: true,
+          };
+        }
+
+        // 2. If it's a legal move, make the move
+        if (state.legalMoves[state.square]?.has(transition.square)) {
+          return this._capturePieceOrMakeMove(
+            state,
+            state.square,
+            transition.square,
+          );
+        }
+
+        // 3. If it's an occupied piece, select the piece
+        const piece = state.game.board.getPiece(transition.square);
+        if (piece) {
+          const isOppositeColor =
+            (state.game.turn % 2 === 0 && piece.color === 'black') ||
+            (state.game.turn % 2 === 1 && piece.color === 'white');
+          const opponentPieceMoves = isOppositeColor
+            ? piece
+                .allSquareMoves(state.game.board)
+                .map((move) => move.toSquare())
+            : undefined;
+
+          return {
+            state: {
+              ...state,
+              name: 'MOUSE_DOWN_PIECE_SELECTED',
+              selectedPiece: piece.toString(),
+              square: transition.square,
+              opponentPieceMoves,
+            },
+            didChange: true,
+          };
+        }
+
+        // 4. Otherwise go back to waiting
+        return {
+          state: {
+            ...state,
+            name: 'WAITING',
+          },
+          didChange: true,
+        };
+      }
+      case 'MOUSE_DOWN_OUTSIDE_BOARD':
+        return {
+          state: {
+            ...state,
+            name: 'WAITING',
+          },
+          didChange: true,
+        };
+      default:
+        return { state, didChange: false };
+    }
+  };
+
+  private _dragPieceStateTransition = (
+    state: DragPieceState,
+    transition: Transition,
+  ): BoardChange => {
+    switch (transition.name) {
+      case 'MOUSE_MOVE_OUTSIDE_BOARD':
+        return {
+          state,
+          didChange: false,
+        };
+      case 'MOUSE_MOVE_SQUARE':
+        return {
+          state: {
+            ...state,
+            dragSquare: transition.square,
+          },
+          didChange: true,
+        };
+      case 'MOUSE_UP_OUTSIDE_BOARD':
+        return {
+          state: {
+            ...state,
+            name: 'MOUSE_UP_PIECE_SELECTED',
+          },
+          didChange: true,
+        };
+      case 'MOUSE_UP': {
+        if (!state.legalMoves[state.square]?.has(transition.square)) {
+          return {
+            state: {
+              ...state,
+              name: 'MOUSE_UP_PIECE_SELECTED',
+            },
+            didChange: true,
+          };
+        }
+        return this._capturePieceOrMakeMove(
+          state,
+          state.square,
+          transition.square,
+        );
+      }
+      default:
+        return { state, didChange: false };
+    }
+  };
+
+  private _cancelSelectionSoonStateTransition = (
+    state: CancelSelectionSoonState,
+    transition: Transition,
+  ): BoardChange => {
+    switch (transition.name) {
+      case 'MOUSE_MOVE_OUTSIDE_BOARD':
+        return {
+          state: {
+            ...state,
+            name: 'DRAG_PIECE',
+            dragSquare: state.square,
+          },
+          didChange: true,
+        };
+      case 'MOUSE_MOVE_SQUARE':
+        return {
+          state: {
+            ...state,
+            name: 'DRAG_PIECE',
+            dragSquare: transition.square,
+          },
+          didChange: true,
+        };
+      case 'MOUSE_UP':
+        return {
+          state: {
+            ...state,
+            name: 'WAITING',
+          },
+          didChange: true,
+        };
+      default:
+        return { state, didChange: false };
+    }
+  };
+}


### PR DESCRIPTION
1. Refactor board-state to be a class instead of just a collection of methods.

This is necessary to be able to fire custom events based on the state or transitions of the state machine.
Allows us to add future such events.

2. Implement furthestforward and furthestback custom events