### PR TITLE
Change event payloads for promoting and promoted events

### DIFF
--- a/src/hexchess-board.ts
+++ b/src/hexchess-board.ts
@@ -453,7 +453,13 @@ export class HexchessBoard extends LitElement {
       ) {
         const move = newState.state.moves[newState.state.moves.length - 1];
         this.dispatchEvent(
-          new CustomEvent('promoting', { detail: { location: move.to } }),
+          new CustomEvent('promoting', {
+            detail: {
+              from: move.from,
+              to: move.to,
+              isCapture: !!move.capturedPiece,
+            },
+          }),
         );
       } else if (
         this._state.game.state() === GameState.PROMOTING &&
@@ -462,7 +468,7 @@ export class HexchessBoard extends LitElement {
         const move = newState.state.moves[newState.state.moves.length - 1];
         this.dispatchEvent(
           new CustomEvent('promoted', {
-            detail: { location: move.to, piece: move.promotion },
+            detail: { piece: move.promotion },
           }),
         );
       } else if (newState.state.name === 'GAMEOVER') {


### PR DESCRIPTION
The promoting event fires before promoted, and it needs to give all the details of the move.
The promoted event fires in the end, and it should only provide the final resulting piece post-promotion.