### PR TITLE
Fix audio base CDN url

### DIFF
--- a/src/audio.ts
+++ b/src/audio.ts
@@ -77,7 +77,7 @@ const normalizeSoundPack = (pack?: SoundPack | null): NormalizedSoundPack => {
 };
 
 const CDN_AUDIO_BASE_URL =
-  'https://github.com/hexagonchess/hexchess-board/docs/assets/audio';
+  'https://hexagonchess.github.io/hexchess-board/assets/audio';
 
 const resolveAssetUrl = (event: SoundEvent): string => {
   if (


### PR DESCRIPTION
Intentionally use the Github pages URL (CDN) rather than the github tree viewer URL.