### PR TITLE
fix promotion logic for pawns when capturing to the A or L files

### DIFF
--- a/src/board-state.ts
+++ b/src/board-state.ts
@@ -264,8 +264,10 @@ export class BoardStateMachine {
     }
     if (
       fromPiece instanceof Pawn &&
-      (Position.fromString(to).isBeginningOfColumn() ||
-        Position.fromString(to).isEndOfColumn())
+      ( 
+        (fromPiece.color === "black" && Position.fromString(to).isBeginningOfColumn()) ||
+        (fromPiece.color === "white" && Position.fromString(to).isEndOfColumn()) 
+      )
     ) {
       return {
         state: {


### PR DESCRIPTION
NOTE: I'm resubmitting this pull request because I somehow pulled the changes on my main branch into the last branch I meant to have just this bugfix. I had meant for the fix to be pulled into my main. This branch contains only the relevant change. I closed the other one.

There is a bug when the B7 or K7 black pawns capture to A6 or L6 that is mistakenly identified as a pawn promotion event by the logic in board-state.ts (around line 265). There is no check for which color the from piece pawn was just that it has reached the beginning or end of a column triggering the promotion transition state. This fix adds an additional check for the color to prevent this issue from occuring.

To demonstrate the bug: load a new game in a browser tab. move white pawn h3 to h4. black pawn f7 to f6. white bishop f1 to l6. black pawn k7 captures white bishop l6. A promotion choice will appear and the game will lockup because no pawns are eligible for promotion. flipping the moves to the A column will yield the same result.

This bug also affects white pawns capturing to the A and L files, and is fixed by the logic change in baord_state.ts .

I was working on expanding this hexchess board to support similar variants like glinski-capablanca, shafran, mccooey, etc when I came across this bug. So I looked into it and found the board-state.ts logic wasn't checking the pawn colors before declaring it a promotion state causing this bug. I wanted to get this fix upstream before continuing.

Let me know if you need any changes to this before accepting for style reasons, etc
